### PR TITLE
🔧 feat(homepage): Add wildcard ALLOWED_HOSTS setting

### DIFF
--- a/big-bear-umbrel-homepage/docker-compose.yml
+++ b/big-bear-umbrel-homepage/docker-compose.yml
@@ -8,6 +8,8 @@ services:
 
   server:
     image: ghcr.io/gethomepage/homepage:v1.2.0
+    environment:
+      - HOMEPAGE_ALLOWED_HOSTS=*
     volumes:
       - ${APP_DATA_DIR}/data/homepage:/app/config # Make sure your local config directory exists
       - /var/run/docker.sock:/var/run/docker.sock:ro # (optional) For docker integrations


### PR DESCRIPTION
- Adds a wildcard `ALLOWED_HOSTS` environment variable to the homepage server container
- Allows the homepage to be accessed from any host, which is useful for deployments where the hostname may not be known in advance