### PR TITLE
🔖 feat(big-bear-umbrel): update app versions

### DIFF
--- a/big-bear-umbrel-adguard-home/umbrel-app.yml
+++ b/big-bear-umbrel-adguard-home/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: big-bear-umbrel-adguard-home
 name: Adguard Home
 category: Networking
-version: "0.0.3"
+version: "v0.107.62"
 tagline: Network-wide ads & trackers blocking DNS server
 icon: https://github.com/walkxcode/dashboard-icons/blob/main/png/adguard-home.png?raw=true
 description: >

--- a/big-bear-umbrel-chromium/docker-compose.yml
+++ b/big-bear-umbrel-chromium/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   server:
     # Service for running Chromium browser in a container
-    image: lscr.io/linuxserver/chromium:latest
+    image: linuxserver/chromium:a4879cda-ls125
 
     # Define security options for the container
     security_opt:

--- a/big-bear-umbrel-chromium/umbrel-app.yml
+++ b/big-bear-umbrel-chromium/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: big-bear-umbrel-chromium
 name: Chromium
 category: Developer Tools
-version: "0.0.3"
+version: "a4879cda-ls125"
 tagline: Self-hosted browser that runs in a container
 icon: https://i.imgur.com/RzEdgMc.png
 description: >

--- a/big-bear-umbrel-cloudflared/umbrel-app.yml
+++ b/big-bear-umbrel-cloudflared/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: big-bear-umbrel-cloudflared
 name: Cloudflared
 category: Networking
-version: "0.0.3"
+version: "2023.7.3"
 tagline: A tunneling daemon by Cloudflare that safely exposes your localhost into the web.
 icon: https://i.imgur.com/ZJBedYy.png
 description: >

--- a/big-bear-umbrel-dashdot/docker-compose.yml
+++ b/big-bear-umbrel-dashdot/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.5'
+version: "3.5"
 
 services:
   app_proxy:
@@ -7,10 +7,10 @@ services:
       APP_PORT: 3001
 
   server:
-    image: mauricenino/dashdot:latest
+    image: mauricenino/dashdot:6.0.0
     volumes:
       - /:/mnt/host:ro
     environment:
-       DASHDOT_ENABLE_CPU_TEMPS: 'true'
+      DASHDOT_ENABLE_CPU_TEMPS: "true"
     restart: unless-stopped
     privileged: true

--- a/big-bear-umbrel-dashdot/umbrel-app.yml
+++ b/big-bear-umbrel-dashdot/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: big-bear-umbrel-dashdot
 name: dash.
 category: Dashboards
-version: "0.0.2"
+version: "6.0.0"
 tagline: Self-hosted dash.
 icon: https://i.imgur.com/BcoQO4Y.png
 description: >

--- a/big-bear-umbrel-flame/umbrel-app.yml
+++ b/big-bear-umbrel-flame/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: big-bear-umbrel-flame
 name: Flame
 category: Dashboards
-version: "0.0.2"
+version: "2.3.1"
 tagline: Self-hosted flame
 icon: https://i.imgur.com/TzyTrX0.png
 description: >

--- a/big-bear-umbrel-ghost/umbrel-app.yml
+++ b/big-bear-umbrel-ghost/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: big-bear-umbrel-ghost
 name: Ghost
 category: Developer Tools
-version: "0.0.6"
+version: "5.120.3"
 tagline: Ghost is a free and open source blogging platform written in JavaScript
 icon: https://i.imgur.com/5RJJOqw.png
 description: >

--- a/big-bear-umbrel-glances/umbrel-app.yml
+++ b/big-bear-umbrel-glances/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: big-bear-umbrel-glances
 name: Glances
 category: Developer Tools
-version: "0.0.3"
+version: "4.3.0.8-full"
 tagline: Glances is an open-source system cross-platform monitoring tool. It allows real-time monitoring of various aspects of your system such as CPU, memory, disk, network usage etc. It also allows monitoring of running processes, logged in users, temperatures, voltages, fan speeds etc. It also supports container monitoring, it supports different container management systems such as Docker, LXC. The information is presented in an easy to read dashboard and can also be used for remote monitoring of systems via a web interface or command line interface. It is easy to install and use and can be customized to show only the information that you are interested in.
 icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/glances.png
 description: >

--- a/big-bear-umbrel-guacamole/umbrel-app.yml
+++ b/big-bear-umbrel-guacamole/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: big-bear-umbrel-guacamole
 name: Guacamole
 category: Developer Tools
-version: "0.0.4"
+version: "1.5.5"
 tagline: Apache Guacamole is a clientless remote desktop gateway supporting protocols like VNC and RDP.
 icon: https://i.imgur.com/pxcsqyl.png
 description: >

--- a/big-bear-umbrel-homepage/umbrel-app.yml
+++ b/big-bear-umbrel-homepage/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: big-bear-umbrel-homepage
 name: Homepage
 category: Dashboards
-version: "0.0.4"
+version: "1.2.0"
 tagline: Self-hosted homepage
 icon: https://i.imgur.com/nAu5Zna.png
 description: >

--- a/big-bear-umbrel-portainer/docker-compose.yml
+++ b/big-bear-umbrel-portainer/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   server:
-    image: portainer/portainer-ce:latest
+    image: portainer/portainer-ce:2.30.1
     restart: always
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/big-bear-umbrel-portainer/umbrel-app.yml
+++ b/big-bear-umbrel-portainer/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: big-bear-umbrel-portainer
 name: Portainer
 category: Developer Tools
-version: "0.0.7"
+version: "2.30.1"
 tagline: Self-hosted container management
 icon: https://github.com/walkxcode/dashboard-icons/blob/main/png/portainer-alt.png?raw=true
 description: >

--- a/big-bear-umbrel-speedtest-tracker-2/docker-compose.yml
+++ b/big-bear-umbrel-speedtest-tracker-2/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 80
 
   server:
-    image: "ghcr.io/alexjustesen/speedtest-tracker:v0.19.0"
+    image: "linuxserver/speedtest-tracker:1.6.0"
     environment:
       - PUID=1000
       - PGID=1000

--- a/big-bear-umbrel-speedtest-tracker-2/umbrel-app.yml
+++ b/big-bear-umbrel-speedtest-tracker-2/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: big-bear-umbrel-speedtest-tracker-2
 name: SpeedTest-Tracker 2
 category: Networking
-version: "0.0.2"
+version: "1.6.0"
 tagline: Self-hosted speedtest-tracker
 icon: https://github.com/alexjustesen/speedtest-tracker/blob/main/public/img/speedtest-tracker-icon.png?raw=true
 description: >

--- a/big-bear-umbrel-speedtest-tracker/docker-compose.yml
+++ b/big-bear-umbrel-speedtest-tracker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 
 services:
   app_proxy:
@@ -7,16 +7,16 @@ services:
       APP_PORT: 80
 
   server:
-   image: henrywhitaker3/speedtest-tracker
-   volumes:
-     - ${APP_DATA_DIR}/speedtest/data:/config
-   environment:
-     - PGID=1000
-     - PUID=1000
-     - OOKLA_EULA_GDPR=true
-   logging:
-     driver: "json-file"
-     options:
-       max-file: "10"
-       max-size: "200k"
-   restart: unless-stopped
+    image: henrywhitaker3/speedtest-tracker:latest
+    volumes:
+      - ${APP_DATA_DIR}/speedtest/data:/config
+    environment:
+      - PGID=1000
+      - PUID=1000
+      - OOKLA_EULA_GDPR=true
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "10"
+        max-size: "200k"
+    restart: unless-stopped

--- a/big-bear-umbrel-uptime-kuma/umbrel-app.yml
+++ b/big-bear-umbrel-uptime-kuma/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: big-bear-umbrel-uptime-kuma
 name: Uptime Kuma
 category: Networking
-version: "0.0.4"
+version: "1.23.16"
 tagline: Self-hosted uptime monitoring tool
 icon: https://i.imgur.com/NQhUQbR.png
 description: >

--- a/big-bear-umbrel-wishlist/umbrel-app.yml
+++ b/big-bear-umbrel-wishlist/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: big-bear-umbrel-wishlist
 name: Wishlist
 category: Collaboration Platforms
-version: "0.42.5"
+version: "v0.42.5"
 tagline: Self-hosted wishlist application
 icon: https://cdn.jsdelivr.net/gh/bigbeartechworld/big-bear-umbrel/big-bear-umbrel-wishlist/logo.png
 description: >


### PR DESCRIPTION
- Portainer updated to version `2.30.1`
- Adguard Home updated to version `v0.107.62`
- Speedtest Tracker updated to version `1.6.0`
- Cloudflared updated to version `2023.7.3`
- dash. updated to version `6.0.0`
- Chromium updated to version `a4879cda-ls125`
- Speedtest Tracker 2 updated to version `1.6.0`
- Portainer Docker image updated to version `2.30.1`
- dash. Docker image updated to version `6.0.0`
- Chromium Docker image updated to version `a4879cda-ls125`
- Glances updated to version `4.3.0.8-full`